### PR TITLE
Fix custom rule

### DIFF
--- a/docs/rules/decorator-position.md
+++ b/docs/rules/decorator-position.md
@@ -57,7 +57,7 @@ module.exports = {
   parser: 'babel-eslint',
   plugins: ['decorator-position'],
   rules: {
-    'decorator-position': [
+    'decorator-position/decorator-position': [
       'error',
       {
         properties: 'prefer-inline',


### PR DESCRIPTION
The custom rule example was missing the `decorator-position` plugin name from the rule, so it did not work.