### PR TITLE
Fine-tune update policy for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@typescript-eslint/parser": "4.3.0",
     "babel-eslint": "10.1.0",
     "common-tags": "1.8.0",
-    "eslint": "7.10.0",
     "eslint-config-prettier": "6.12.0",
     "eslint-plugin-eslint-comments": "3.2.0",
     "eslint-plugin-eslint-plugin": "2.3.0",
@@ -88,7 +87,7 @@
     "ember-rfc176-data": "^0.3.12",
     "snake-case": "^3.0.3",
     "prettier": "2.1.2",
-    "eslint": "7.10.0"
+    "eslint": "^7.10.0"
   },
   "changelog": {
     "repo": "NullVoxPopuli/eslint-plugin-decorator-position",

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,11 @@
     "smoke-tests"  
   ],
   "automerge": true,
-  "masterIssue": true
+  "masterIssue": true,
+  "packageRules": [
+    {
+      "packageNames": ["eslint"],
+      "rangeStrategy": "bump"
+    }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3003,7 +3003,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@7.10.0:
+eslint@^7.10.0:
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.10.0.tgz#494edb3e4750fb791133ca379e786a8f648c72b9"
   integrity sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==
@@ -6203,7 +6203,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -6218,7 +6217,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -6237,14 +6235,8 @@ npm@^6.10.3:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
- Use `^` for eslint in `package.json`
- Fix dependency collision by removing eslint from devDependencies
  (since it's present in dependencies)
- Set eslint's [rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy) to "bump" in `renovate.json`

These changes will prevent issues like #138 from happening in the future.

Fix #138