### PR TITLE
chore: drop support fore node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       matrix:
         node:
-        - "10"
         - "12"
+        - "14"
+        - "16"
     steps:
     - uses: actions/checkout@v2
     - uses: volta-cli/action@v1


### PR DESCRIPTION
BREAKING CHANGE: node < 12 is no longer supported.

Added node 14 and 16 to the test matrix