### PR TITLE
Widen `@babel/eslint-parser` peerdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "vitest": "0.31.1"
   },
   "peerDependencies": {
-    "@babel/eslint-parser": "^7.18.2",
+    "@babel/eslint-parser": "^7.18.2 || ^8.0.0",
     "eslint": "^7.31.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
The `eslint` peer range was widened to include `^10.0.0` in #788, but the optional `@babel/eslint-parser` was still at `^7.18.2`, which is not compatible with eslint 10.